### PR TITLE
Defaulting to the browserslist default string

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -8,7 +8,7 @@ const GA_ID = process.env.GA_ID
 
 /* GET home page. */
 router.get('/', function(req, res) {
-  const query = req.query.q || "> 5%"
+  const query = req.query.q || browserslist.defaults.join(", ")
   let bl = null
   try {
     bl = browserslist(query)


### PR DESCRIPTION
closes https://github.com/jonrohan/browserl.ist/issues/2

This uses the `browserslist.defaults` string for the default query instead of the hardcoded `> 5%`.

cc @ai