### PR TITLE
Upgrading browserslist and using 'defaults'

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "body-parser": "~1.15.1",
-    "browserslist": "^1.3.6",
+    "browserslist": "^1.4.0",
     "caniuse-db": "^1.0.30000506",
     "cookie-parser": "~1.4.3",
     "debug": "~2.2.0",

--- a/routes/index.js
+++ b/routes/index.js
@@ -8,7 +8,7 @@ const GA_ID = process.env.GA_ID
 
 /* GET home page. */
 router.get('/', function(req, res) {
-  const query = req.query.q || browserslist.defaults.join(", ")
+  const query = req.query.q || "defaults"
   let bl = null
   try {
     bl = browserslist(query)


### PR DESCRIPTION
closes https://github.com/jonrohan/browserl.ist/issues/9

This pull updates browserslist and uses the new "defaults" query which will expand out the default browsers.