### PR TITLE
Display regional stats for `in` queries

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -7,9 +7,28 @@ const caniuse = require('caniuse-db/data.json').agents
 const GA_ID = process.env.GA_ID
 const pkg = require('../package.json')
 
+let caniuseRegion
+
+function getCoverage(data, version) {
+  // If specific version coverage is missing, fall back to "version zero"
+  return data[version] !== undefined ? data[version] : data[0]
+}
+
+function getRegionCoverage(region, id, version) {
+  if (!caniuseRegion) {
+    caniuseRegion = require('caniuse-db/region-usage-json/' + region + '.json')
+  }
+
+  return getCoverage(caniuseRegion.data[id], version)
+}
+
 /* GET home page. */
 router.get('/', function(req, res) {
   const query = req.query.q || "defaults"
+  const queryHasIn = query.match(/ in ((?:alt-)?[A-Za-z]{2})(?:,|$)/)
+
+  const region = queryHasIn ? queryHasIn[1] : undefined
+
   let bl = null
   try {
     bl = browserslist(query)
@@ -29,18 +48,24 @@ router.get('/', function(req, res) {
   if (bl) {
     bl.map((b) => {
       b = b.split(" ")
-      const db = caniuse[b[0]]
+
+      const id = b[0]
+      const version = b[1]
+
+      const db = caniuse[id]
+
+      const coverage = region ? getRegionCoverage(region, id, version) : getCoverage(db.usage_global, version)
 
       if(!compatible[db.type]) {
         compatible[db.type] = []
       }
 
       compatible[db.type].push({
-        "version": b[1],
-        "id": b[0],
+        "version": version,
+        "id": id,
         "name": db.browser,
-        "coverage": db.usage_global[b[1]],
-        "logo": "/images/" + b[0] + ".png"
+        "coverage": coverage,
+        "logo": "/images/" + id + ".png"
       })
     })
   }
@@ -50,8 +75,9 @@ router.get('/', function(req, res) {
     query: query,
     GA_ID: GA_ID,
     blversion: pkg.dependencies["browserslist"],
-    coverage: browserslist.coverage(bl),
-    description: "A page to display compatible browsers from a browserslist string."
+    coverage: browserslist.coverage(bl, region),
+    description: "A page to display compatible browsers from a browserslist string.",
+    region: region || 'Global'
   })
 })
 

--- a/views/index.pug
+++ b/views/index.pug
@@ -22,8 +22,12 @@ block content
                 span(class="mr1 v-mid") #{browser.name}
                 span(class="mr1 v-mid") #{browser.version}
                 span(class="v-mid fr")
-                  small(alt="Global coverage") #{Math.round(browser.coverage * 100) / 100}%
+                  small(alt="Coverage") #{Math.round(browser.coverage * 100) / 100}%
     else if error != null
       h2(class="f4 f3-ns ma0 mv5 tc ttc") #{error}
-  div(class="tc bg-neon-carrot plum bb b--black-10 pa2 pa3-ns mt4") Global coverage:
-    strong(class="ml1") #{Math.round(coverage * 100) / 100}%
+  div(class="tc bg-neon-carrot plum bb b--black-10 pa2 pa3-ns mt4")
+    if compatible
+      | #{region} coverage:
+      strong(class="ml1") #{Math.round(coverage * 100) / 100}%
+    else
+      | Unknown coverage


### PR DESCRIPTION
# Global

![screen shot 2018-02-15 at 4 11 38 pm](https://user-images.githubusercontent.com/155798/36288129-0e3f72bc-126e-11e8-828f-0e6aa0c69b4f.png)

# Regional

![screen shot 2018-02-15 at 4 15 24 pm](https://user-images.githubusercontent.com/155798/36288126-0b9ac4c6-126e-11e8-9ae9-f8e750be412d.png)

----
Closes #75