### PR TITLE
Strip quotation marks from query pasted from a package.json file.

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -33,7 +33,10 @@ router.get('/', function(req, res) {
 
   let bl = null
   try {
-    bl = browserslist(query)
+    // Remove quotes to allow users to copy multiline strings,
+    // e.g., from their package.json file.
+    const queryWithoutQuotes = query.replace(/"/g, "")
+    bl = browserslist(queryWithoutQuotes)
   } catch (e) {
     // Error
     return res.render('index', {


### PR DESCRIPTION
Thanks for building this site!

This partially fixes #55 to allow people to paste their browserslist config directly from a `package.json` file.

For instance, my `package.json` looks like this:
```
"browserslist": [
    ">0.19%",
    "not dead",
    "not ie <= 10",
    "not op_mini all",
    "ios_saf >= 9.0"
],
```

This PR allows me to copy/paste the following directly into the form and get the desired results:

```
     ">0.19%",     "not dead",     "not ie <= 10",     "not op_mini all",     "ios_saf >= 9.0"
```

Thanks for considering this PR, and please let me know if any questions/comments/suggestions!